### PR TITLE
Fix copyright notice

### DIFF
--- a/library/src/main/java/com/theta360/pluginlibrary/UncaughtException.java
+++ b/library/src/main/java/com/theta360/pluginlibrary/UncaughtException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/library/src/main/java/com/theta360/pluginlibrary/activity/Constants.java
+++ b/library/src/main/java/com/theta360/pluginlibrary/activity/Constants.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Ricoh Company, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.theta360.pluginlibrary.activity;
 
 final class Constants {

--- a/library/src/main/java/com/theta360/pluginlibrary/activity/PluginActivity.java
+++ b/library/src/main/java/com/theta360/pluginlibrary/activity/PluginActivity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/library/src/main/java/com/theta360/pluginlibrary/callback/KeyCallback.java
+++ b/library/src/main/java/com/theta360/pluginlibrary/callback/KeyCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/library/src/main/java/com/theta360/pluginlibrary/callback/TakePictureCallback.java
+++ b/library/src/main/java/com/theta360/pluginlibrary/callback/TakePictureCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/library/src/main/java/com/theta360/pluginlibrary/receiver/KeyReceiver.java
+++ b/library/src/main/java/com/theta360/pluginlibrary/receiver/KeyReceiver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Ricoh Company, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
* The copyright notice was written as a javadoc-style comment. However, the copyright notice is not a Javadoc. Therefore, I replaced javadoc-style comments with regular block-style comments.
* I added the copyright notice to some files.
